### PR TITLE
fix: unitGoroutine

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -85,18 +85,18 @@ func unitGoroutine(
 		metricC:                     metricC,
 	}
 
+	// Ignore error because cookiejar.New never return a error.
+	jar, _ := cookiejar.New(nil)
+	client := newClient(&http.Client{
+		// For create a new connection each loop.
+		Transport: newTransport(),
+		// For share cookie within all requests of one runFunc runtime.
+		Jar: jar,
+	})
+	httpImpl.client = client
+
 	isInitDone := false
 	for {
-		// Ignore error because cookiejar.New never return a error.
-		jar, _ := cookiejar.New(nil)
-		client := newClient(&http.Client{
-			// For create a new connection each loop.
-			Transport: newTransport(),
-			// For share cookie within all requests of one runFunc runtime.
-			Jar: jar,
-		})
-		httpImpl.client = client
-
 		select {
 		case <-cancelC:
 			return


### PR DESCRIPTION
Hi @lifenod , I found a possible bug when I used this package for performance testing.

I found that every http request will establish a new tcp connection. When my request rate reaches 2000/s, it will occupy all available sockets on my machine in 30 seconds.

Maybe the original intention of this code is to share a client for each unitGoroutine instead of creating a client for each request?


